### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/export-configure.py
+++ b/export-configure.py
@@ -44,7 +44,7 @@ def export(payload, target):
         return
     for service in sorted(payload, key=lambda item: item['title']):
         fast_ip = find_fast_ip(service['ips'])
-        print('# %(title)s' % service)
+        print('# {title!s}'.format(**service))
         for domain in sorted(service['domains'], key=len):
             template = '%s'
             if not fast_ip:
@@ -59,7 +59,7 @@ def load_payload():
     target_filename = 'apple-cdn-speed.report'
     if os.path.exists(target_filename):
         return json.load(open(target_filename, encoding='UTF-8'))
-    print('please run "fetch-timeout.py" build "%s".' % target_filename)
+    print('please run "fetch-timeout.py" build "{0!s}".'.format(target_filename))
 
 
 def main():

--- a/fetch-timeout.py
+++ b/fetch-timeout.py
@@ -50,7 +50,7 @@ def handle_ip(target):
     except ImportError:
         from urlparse import urlparse
 
-    address = urlparse('http://%s' % target)
+    address = urlparse('http://{0!s}'.format(target))
     return address.hostname, address.port or 80
 
 
@@ -70,9 +70,9 @@ def fetch(payload):
                     key=lambda item: item['delta']
                 )
                 service_item['ips'][name] = ips
-                print('\t%s' % name)
+                print('\t{0!s}'.format(name))
                 for item in ips:
-                    print('\t\t%(ip)-15s\t%(delta)sms' % item)
+                    print('\t\t{ip:<15!s}\t{delta!s}ms'.format(**item))
     return payload
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:AppleDNS?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:AppleDNS?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
